### PR TITLE
Updates Travis CI Template

### DIFF
--- a/generators/app/templates/cli/.travis.yml
+++ b/generators/app/templates/cli/.travis.yml
@@ -9,4 +9,4 @@ cache:
 script:
 - yarn lint
 - yarn jest
-- yarn danger
+- yarn danger ci

--- a/generators/app/templates/cli/.travis.yml
+++ b/generators/app/templates/cli/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+node_js: '10'
 
 cache:
   yarn: true


### PR DESCRIPTION
`yarn danger` only prints out the help info for Danger, so this updates the Travis CI template with the new invocation. I've also specified the Node version, since Travis' default Node version is too old to install Yarn 😅 