### PR TITLE
Use ts-node for lint script

### DIFF
--- a/generators/app/templates/cli/package.json
+++ b/generators/app/templates/cli/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "type-check": "tsc --noEmit",
     "build": "tsc",
-    "lint": "tslint 'src/**/*.{ts,tsx}'",
+    "lint": "ts-node node_modules/.bin/tslint 'src/**/*.{ts,tsx}'",
     "release": "release-it"
   },
   "jest": {


### PR DESCRIPTION
I've been using this tool a lot lately and the first thing I do every time is update the `lint` script to use `ts-node`. This changes the template to use `ts-node` by default. Using `ts-node` lets us write our custom TSLint rules _in_ TypeScript, which would otherwise require a lot of effort to compile them before being run. 